### PR TITLE
#26: app crashes

### DIFF
--- a/client/src/common/constants.ts
+++ b/client/src/common/constants.ts
@@ -1,2 +1,3 @@
+export const DEFAULT_API_URL = 'http://localhost:3001';
 export const MAX_NOTIFICATIONS = 2;
 export const AUTOCLOSE_IN_MILISEC = 5000;

--- a/client/src/services/api.service.ts
+++ b/client/src/services/api.service.ts
@@ -1,10 +1,11 @@
 import axios from 'axios';
 import { toast } from 'react-toastify';
 import { IScrappedData } from 'common/interfaces';
+import { DEFAULT_API_URL } from 'common/constants';
 
 const service = {
   getScrappedInfo: async (url: string): Promise<IScrappedData> => {
-    const serverURL = process.env.REACT_APP_API_URL;
+    const serverURL = process.env.REACT_APP_API_URL ?? DEFAULT_API_URL;
     const endpoint = serverURL ? `${serverURL}/info` : '';
     const response: IScrappedData = await axios.get(
       endpoint,

--- a/server/scrapping-manager.js
+++ b/server/scrapping-manager.js
@@ -62,11 +62,17 @@ class ScrappingManager {
   }
 
   #detectLargestImage(items) {
-    return items.reduce(function (current, potential) {
+    const result = items.reduce(function (current, potential) {
       const squareOfPotential = potential.width * potential.height;
-      const squareOfCurrent = current.width * current.height;
+      const squareOfCurrent = current?.width * current?.height;
       return squareOfCurrent > squareOfPotential ? current : potential;
-    });
+    }, null);
+
+    return result ?? {
+      url: 'None',
+      width: 0,
+      height: 0,
+    };
   }
 
   async #getImageDimensions(url) {

--- a/server/service.js
+++ b/server/service.js
@@ -7,6 +7,7 @@ async function getInfoOfWebPage(req, res) {
   const { data, loadingTimeInSec } = await httpService.get(url);
   const scrappingManager = new ScrappingManager(url);
   scrappingManager.loadPage(data);
+  const result = await scrappingManager.getScrappedData();
   res.json(mapDataToSingleStructure({ ...result, loadingTimeInSec }));
 }
 


### PR DESCRIPTION
If run the project and submit a link, response of that request was HTML with text "You need to enable JavaScript to run this page",  caused by .env absence and particularly API_URL.
The second bug was in the mapping function. Variable "result" was not defined. Forget to call appropriate method of ScrappingManager.
And in some cases detectLargeImage crashed as well because the website doesn't have any images. Initial value of reduce was not set.

fixes #26 